### PR TITLE
Do not compile rdtsc on android or ios.

### DIFF
--- a/gstuff.rs
+++ b/gstuff.rs
@@ -471,7 +471,7 @@ macro_rules! find_parse_replace_s {
 
 /// Time Stamp Counter (number of cycles).
 #[cfg(feature = "nightly")]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "android", target_os = "ios")))]
 pub fn rdtsc() -> u64 {
   // https://stackoverflow.com/a/7617612/257568
   // https://github.com/gz/rust-x86/blob/master/src/bits64/time.rs


### PR DESCRIPTION
I got
```
error: couldn't allocate output register for constraint '{eax}'
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/gstuff-0.5.10/gstuff.rs:477:5
    |
477 |     asm!("rdtsc" : "={eax}" (low), "={edx}" (high) ::: "volatile");
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
while trying to build for Android. I suspect there might be issue with iOS too.